### PR TITLE
docs: refine README formatting and mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛰️ systemsignal.dev
 
-> A digital publication, portfolio, and philosophy engine by **Karthik Mohan**  
+> A digital publication, portfolio, and philosophy engine by **Karthik Mohan**
 > Product Strategist · Systems Thinker · Builder of Trust-First Technology
 
 ---
@@ -9,71 +9,80 @@
 
 **System Signal** is my personal platform for exploring and publishing ideas at the intersection of:
 
-- Product Strategy & Systems Design  
-- Distributed Tech (Blockchain, Zero Trust, Auditable AI)  
-- Philosophy, Futurism, and Dharmic Thought  
+- Product Strategy & Systems Design
+- Distributed Tech (Blockchain, Zero Trust, Auditable AI)
+- Philosophy, Futurism, and Dharmic Thought
 - Narrative Interfaces and Ethical Technology
 
-Built with **Jekyll + GitHub Pages**. Hosted at [https://systemsignal.dev](https://systemsignal.dev)
+Built with **Jekyll + GitHub Pages**. Hosted at [https://systemsignal.dev](https://systemsignal.dev).
 
 ---
 
 ## 🗂️ Pages & Navigation
 
-| Route | Description |
-|-------|-------------|
-| `/` | Homepage with mission, philosophy, and project links  
-| `/about` | Full professional bio & current work  
-| `/projects` | Case studies: TrustBridge, Kaya, LoopList, CityFlow  
-| `/philosophy` | My core product & systems principles  
-| `/library` | Curated digital canon of tech, ethics, and civilizational ideas  
-| `/writing` | Essays and longform reflections  
-| `/consulting` | Strategy offerings and calendar booking  
-| `/links` | Linktree-style landing page  
+| Route | Source | Description |
+|-------|--------|-------------|
+| `/` | `index.md` | Homepage with mission, philosophy, and project links |
+| `/about` | `about.md` | Full professional bio & current work |
+| `/blueprints` | `blueprints.md` | Speculative systems and R&D lab |
+| `/projects` | `projects.md` | Case studies: TrustBridge, Kaya, LoopList, CityFlow |
+| `/philosophy` | `philosophy.md` | Core product & systems principles |
+| `/library` | `library.md` | Curated digital canon of tech, ethics, and civilizational ideas |
+| `/writing` | `writing.md` | Essays and longform reflections |
+| `/consulting` | `consulting.md` | Strategy offerings and calendar booking |
+| `/contact` | `contact.md` | Direct email and calendar booking |
+| `/links` | `links.md` | Linktree-style landing page |
+| `/signalstack` | `signalstack.md` | Tools and technologies behind System Signal |
+| `/thesis` | `thesis.md` | Unifying theory and longform research notes |
 
 ---
 
 ## 🧰 Tech Stack
 
-- **Jekyll** – static site generator  
-- **GitHub Pages** – hosting + DNS + HTTPS  
-- **Markdown** – content writing  
-- **Custom CSS** – dark theme + retro visuals  
-- **Manual SEO** – OG/Twitter cards, meta tags  
+- **Jekyll** – static site generator
+- **GitHub Pages** – hosting + DNS + HTTPS
+- **Markdown** – content writing
+- **Custom CSS** – dark theme + retro visuals
+- **Manual SEO** – OG/Twitter cards, meta tags
 - **Calendly Embed** – for booking consulting sessions
 
 ---
 
 ## 📁 Repo Structure
 
-├── index.md # Home
-├── about.md # Bio
-├── projects.md # Case studies
-├── philosophy.md # Belief system
-├── library.md # Curated references
-├── writing.md # Blog hub
-├── consulting.md # Booking services
-├── links.md # Linktree
+```text
+├── index.md            # Home
+├── about.md            # Bio
+├── blueprints.md       # System blueprints
+├── projects.md         # Case studies
+├── philosophy.md       # Belief system
+├── library.md          # Curated references
+├── writing.md          # Blog hub
+├── consulting.md       # Booking services
+├── contact.md          # Contact page
+├── links.md            # Linktree
+├── signalstack.md      # Tooling notes
+├── thesis.md           # Thesis & research
 ├── _layouts/
-│ └── default.html # Page layout with nav + footer
+│   └── default.html    # Page layout with nav + footer
 ├── assets/
-│ ├── css/
-│ │ └── dark.css # Custom dark theme
-│ ├── *.png # Banners & dividers
-├── CNAME # Custom domain config
-├── README.md # You are here
-
-
+│   ├── css/
+│   │   └── dark.css    # Custom dark theme
+│   ├── *.png           # Banners & dividers
+├── CNAME               # Custom domain config
+└── README.md           # You are here
+```
 
 ---
 
 ## 📫 Contact & Credits
 
-- 🧠 Built and maintained by [@elkarto91](https://github.com/elkarto91)  
-- 🌐 Live at [systemsignal.dev](https://systemsignal.dev)  
+- 🧠 Built and maintained by [@elkarto91](https://github.com/elkarto91)
+- 🌐 Live at [systemsignal.dev](https://systemsignal.dev)
 - 📬 Contact via [LinkedIn](https://linkedin.com/in/karthik-m-portfolio)
 
 ---
 
-> “Signal over noise. Story over silo. Meaning over metrics.”  
+> “Signal over noise. Story over silo. Meaning over metrics.”
 > — [systemsignal.dev](https://systemsignal.dev)
+


### PR DESCRIPTION
## Summary
- Reformat README with clearer markdown sections and code block for repo tree.
- Add explicit route-to-source mapping for all site pages.
- Expand site description and contact details for completeness.

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6a5bd9c4832d9800b3556d41b9af