### PR TITLE
Remove philosophy references from site content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛰️ systemsignal.dev
 
-> A digital publication, portfolio, and philosophy engine by **Karthik Mohan**
+> A digital publication and portfolio by **Karthik Mohan**
 > Product Strategist · Systems Thinker · Builder of Trust-First Technology
 
 ---
@@ -11,7 +11,7 @@
 
 - Product Strategy & Systems Design
 - Distributed Tech (Blockchain, Zero Trust, Auditable AI)
-- Philosophy, Futurism, and Dharmic Thought
+- Futurism and Dharmic Thought
 - Narrative Interfaces and Ethical Technology
 
 Built with **Jekyll + GitHub Pages**. Hosted at [https://systemsignal.dev](https://systemsignal.dev).
@@ -32,7 +32,7 @@ Built with **Jekyll + GitHub Pages**. Hosted at [https://systemsignal.dev](https
 =======
 | Route | Source | Description |
 |-------|--------|-------------|
-| `/` | `index.md` | Homepage with mission, philosophy, and project links |
+| `/` | `index.md` | Homepage with mission and project links |
 | `/about` | `about.md` | Full professional bio & current work |
 | `/blueprints` | `blueprints.md` | Speculative systems and R&D lab |
 | `/projects` | `projects.md` | Case studies: TrustBridge, Kaya, LoopList, CityFlow |

--- a/index.md
+++ b/index.md
@@ -140,7 +140,7 @@ I build fantasy worlds, explore systems through storytelling, and create collabo
 
 | Category                               | Subcategory                            | Individuals / Works         | Key Themes                                                                                                  |
 |----------------------------------------|----------------------------------------|------------------------------|-------------------------------------------------------------------------------------------------------------|
-| I. Foundations (Logic & Core Values)   | Philosophy & Values                    | Swami Vivekananda            | Self-realization, strength, practical spirituality, leveraging individual potential                         |
+| I. Foundations (Logic & Core Values)   | Values                                 | Swami Vivekananda            | Self-realization, strength, practical spirituality, leveraging individual potential                         |
 |                                        |                                        | Joe Rogan                    | Open discourse, critical inquiry, challenging norms, diverse perspectives                                   |
 |                                        | Right Libertarian Thought             | Balaji Srinivasan            | Network states, decentralization, technological sovereignty, individual agency, market solutions            |
 |                                        |                                        | Naval Ravikant               | Wealth creation, individual freedom, leveraging, first principles thinking                                  |
@@ -154,7 +154,7 @@ I build fantasy worlds, explore systems through storytelling, and create collabo
 | III. Immersive Worlds (Anime & Sci-Fi) | Action & Growth (Anime)               | Naruto                       | Willpower, perseverance, community, achieving dreams despite odds                                           |
 |                                        |                                        | Dragon Ball                  | Power, training, pushing limits, good vs. evil                                                              |
 |                                        |                                        | Beyblade                     | Strategy, competitive spirit, individual skill                                                              |
-|                                        | Philosophical Depth & Mystery (Anime) | Death Note                   | Justice, morality, power, consequences of absolute control                                                  |
+|                                        | Depth & Mystery (Anime)               | Death Note                   | Justice, morality, power, consequences of absolute control                                                  |
 |                                        |                                        | Fullmetal Alchemist          | Equivalent exchange, human nature, consequences of ambition, brotherhood                                   |
 |                                        |                                        | Attack on Titan              | Survival, freedom, societal secrets, moral ambiguity                                                        |
 |                                        |                                        | Dandadan                     | Unique blend of action, supernatural, humor, exploring unknown                                              |
@@ -163,7 +163,7 @@ I build fantasy worlds, explore systems through storytelling, and create collabo
 |                                        |                                        | Lord of the Rings            | Heroism, mythology, fellowship, sacrifice, the battle between good and evil                                 |
 |                                        |                                        | Warcraft                     | Factions, magic, honor, epic conflicts, world-building                                                      |
 |                                        |                                        | Skyrim                       | Freedom, prophecy, ancient power, immersive open world                                                      |
-|                                        | Philosophical Depth & Mystery (Film)  | Shutter Island               | Reality vs illusion, psychological trauma, perception, paranoia                                             |
+|                                        | Depth & Mystery (Film)                | Shutter Island               | Reality vs illusion, psychological trauma, perception, paranoia                                             |
 
 
 ---

--- a/thesis.md
+++ b/thesis.md
@@ -34,7 +34,7 @@ This site is here to do two things:
 
 It’s my portfolio as a product strategist, a playground for system design, and a public journal for those trying to build things that matter.
 
-If you're a founder, engineer, PM, or philosopher-engineer hybrid — you're in the right room.
+If you're a founder, engineer, or PM — you're in the right room.
 
 ---
 
@@ -50,7 +50,7 @@ In this world, the next generation of builders must:
 - Design **systems that remember**
 - Build **products that prove**
 - Create **interfaces that teach**
-- Lead with **philosophy, not just metrics**
+- Lead with **meaning, not just metrics**
 
 ---
 
@@ -87,7 +87,7 @@ A world of:
 - Systems that don’t forget  
 - AI that can be audited  
 - Products that slow down to be clear  
-- Teams that think like philosophers  
+- Teams that think deeply
 - Interfaces that honor silence, ambiguity, grief, and time
 
 ---


### PR DESCRIPTION
## Summary
- Strip philosophy mentions from README overview, navigation table, and content bullet list.
- Simplify influences table in `index.md` to remove philosophy categories.
- Reword thesis notes to focus on meaning and deep thinking instead of philosophy.

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689f7515a4e0832d851af23bcc0bc3e5