### PR TITLE
Add Neuralic blueprint and reorder Signal Stack

### DIFF
--- a/signalstack.md
+++ b/signalstack.md
@@ -20,26 +20,69 @@ Fictional but feasible — these are fully mapped product ideas exploring unbuil
 
 ---
 
-### 🧭 **ChronoLedger**  
-A programmable ledger for *time-based trust* — where value unlocks or decays based on verified timelines.
+### 🧠 Neuralic
 
-**Use Cases:**
-- Energy credits that expire  
-- Grief grants that fade gradually  
-- Probation periods on social platforms  
-- Amnesty zones in civic governance
+🧠 **Neuralic AI Governance & Reasoning Platform**
 
-**Lifecycle Summary:**  
-- **Stack:** Solidity + Hedera  
-- **GTM:** ESG dashboards + municipal partners  
-- **Frameworks:** RACI, PRD, EOL  
-- **Challenge:** Oracles, TTL misalignment  
-[→ Full Lifecycle](#chronoledger-lifecycle)
+**Modules & Roles**
 
+| Module | Layer | Role |
+| --- | --- | --- |
+| [Neuralic.Core](https://github.com/signalbuilds/neuralic-core) | Governance Fabric | Logging, tracing, and policy enforcement across AI workflows. |
+| Neuralic.Trace | Decision Chain Tracing | Shows how every AI outcome was produced across multi-agent chains. |
+| Neuralic.Orbit | System Integrations | Connector layer for ERP, CRM, APIs, Slack, Notion, etc. |
+| Neuralic.Xplain | AI Explainability | LLM and model output introspection — SHAP, COT, rationales. |
+| Neuralic.Engine | Cognitive Core | The central decision brain — LLMs, retrieval, inference pipelines. |
+| Neuralic.Memory | Vector Recall | Persona memory, embeddings, and contextual history management. |
+| Neuralic.Rules | Reasoning Layer | Guardrails, constraints, logic tree evaluations, custom rule handling. |
+
+**Brand Architecture**
+
+- **Name:** Neuralic  
+- **Tagline Options:**  
+  - “Where AI thinks with reason — and proves it.”  
+  - “Intelligent. Explainable. Enterprise AI governance.”  
+  - “The cognitive control system for enterprise AI.”  
+
+**Benefits**
+
+| Advantage | Result |
+| --- | --- |
+| 🔄 Single Brand Focus | Easier to market, protect, and scale — Neuralic becomes a powerful enterprise name. |
+| 🧠 Cognitive Branding | Reinforces the idea of explainable, responsible, and intelligent AI. |
+| 🧱 Modular Scalability | Each module feels like a product — ready for SaaS packaging or cloud APIs. |
+| 🧩 Plug-and-Play Interoperability | All modules are tightly coupled under a shared system but independently usable. |
+
+**Repo Map**
+
+- [neuralic-core](https://github.com/signalbuilds/neuralic-core) – Central orchestration, configuration, user/session management, audit bus, and common service registry.  
+- [neuralic-trace](https://github.com/signalbuilds/neuralic-trace) – Logs, explains, and visualizes decision chains from LLM or multi-agent systems.  
+- [neuralic-xplain](https://github.com/signalbuilds/neuralic-xplain) – Hosts LLM explainability models: SHAP, CoT, rationale extraction.  
+- [neuralic-orbit](https://github.com/signalbuilds/neuralic-orbit) – Connector service for ERP, Slack, Notion, CRM – powered by plug-in adapters.  
+- [neuralic-engine](https://github.com/signalbuilds/neuralic-engine) – The LLM brain, embedding workflows, decision logic; ties in AI inference pipeline.  
+- [neuralic-memory](https://github.com/signalbuilds/neuralic-memory) – Vector store management, persona embedding recall, semantic graph memory.  
+- [neuralic-rules](https://github.com/signalbuilds/neuralic-rules) – Governance rule engine – define, validate, and enforce AI behavior contracts.  
+
+**neuralic-core – Central Governance Orchestrator**
+
+- **Features:** Service registry, global auth, role-based policy execution engine, Pub/Sub decision tracking, audit log collector.  
+- **Technologies:** Golang or Node.js, PostgreSQL or Redis, gRPC/REST, OpenTelemetry, JWT.  
+- **Modules:** `service-manager/`, `auth/`, `audit-collector/`, `config-center/`.  
+- **API Overview:** `POST /register`, `GET /status`, `POST /decision-log`.  
+- **Setup:**  
+  ```bash
+  git clone https://github.com/signalbuilds/neuralic-core
+  cd neuralic-core
+  docker-compose up --build
+  ```
+
+**Our Learning Journey**
+
+As we build each repo, we'll explore core architectural patterns, API gateway vs service mesh, interpretable AI logic, vector DB design, plugin adapters, LLM inference pipelines, rule graph models, and observability.
 
 ---
 
-## 🪙 Operary
+### 🪙 Operary
 
 > *A minimal trust layer for verifiable work.*
 
@@ -51,6 +94,24 @@ A programmable ledger for *time-based trust* — where value unlocks or decays b
 
 → [View Code →](https://github.com/elkarto91/operary)  
 → [Explore API →](https://operary.systemsignal.dev/docs)
+
+---
+
+### 🧭 **ChronoLedger**
+A programmable ledger for *time-based trust* — where value unlocks or decays based on verified timelines.
+
+**Use Cases:**
+- Energy credits that expire
+- Grief grants that fade gradually
+- Probation periods on social platforms
+- Amnesty zones in civic governance
+
+**Lifecycle Summary:**
+- **Stack:** Solidity + Hedera
+- **GTM:** ESG dashboards + municipal partners
+- **Frameworks:** RACI, PRD, EOL
+- **Challenge:** Oracles, TTL misalignment
+[→ Full Lifecycle](#chronoledger-lifecycle)
 
 ---
 


### PR DESCRIPTION
## Summary
- add Neuralic AI Governance & Reasoning Platform section with repo links and architecture details
- reorder Signal Stack so Neuralic precedes Operary and ChronoLedger

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f77a722d4832d9b808ad6c8584068